### PR TITLE
MQE-1017: Better Error Messaging When Non-Whitespace Characters Are

### DIFF
--- a/guides/v2.3/magento-functional-testing-framework/release-2/commands/mftf.md
+++ b/guides/v2.3/magento-functional-testing-framework/release-2/commands/mftf.md
@@ -104,6 +104,7 @@ opt                | description|
 `--force`           | force generation of tests regardless of Magento Instance Configuration  
 `--lines=LINES`     | Used in combination with a parallel configuration, determines desired group size [default: 500]  
 `--tests=TESTS`     | A parameter accepting a JSON string used to determine the test configuration  
+`--debug`           | Generates tests with extra schema validation to narrow down issues
 
 ##### Examples of the JSON configuration
 


### PR DESCRIPTION
Outside XML Elements

- Adding debug argument for mftf

<!-- (REQUIRED) What is the nature of this PR? -->
## This PR is a:
- [ ] New topic
- [x] Content fix or rewrite
- [ ] Bug fix or improvement
 
<!-- (REQUIRED) What does this PR change? -->
## Summary
 
When this pull request is merged, it will...
 
<!-- (OPTIONAL) What other information can you provide about this PR? -->
## Additional information

<!--
Thank you for your contribution!
 
Before submitting this pull request, please make sure you have read our Contribution Guidelines and your PR meets our contribution standards:
https://devdocs.magento.com/guides/v2.2/contributor-guide/contributing_docs.html
 
Please fill out as much information as you can about your PR to help speed up the review process.
If your PR addresses an existing GitHub Issue, please refer to it in the title or Additional Information section to make the connection.
 
We may ask you for changes in your PR in order to meet the standards set in our Contribution Guidelines. PR's that do not comply with our guidelines may be closed at the maintainers' discretion.

Feel free to remove this section before creating this PR.
-->
